### PR TITLE
2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6-module-starter",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Starter kit to create npm modules using ES6 and Babel with sensible defaults",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Starter kit to create npm modules using ES6 and Babel with sensible defaults",
   "main": "dist/index.js",
   "scripts": {
+    "dev": "babel-node src/index.es6",
     "lint": "eslint src/**/*.es6",
-    "compile": "babel --experimental -d dist/ src/",
+    "compile": "babel --stage 0 -d dist/ src/",
     "prepublish": "npm run compile",
-    "tape": "npm run compile && node node_modules/argg dist/test/*.js",
+    "tape": "babel-node node_modules/argg src/test/*.es6",
     "istanbul": "npm run compile && istanbul cover --dir coverage/istanbul node_modules/argg dist/test/*.js --report lcovonly",
     "coverage": "npm run compile && istanbul cover --dir coverage/istanbul node_modules/argg dist/test/*.js --report html",
     "coveralls": "cat ./coverage/istanbul/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
@@ -31,14 +32,14 @@
   "author": "Vinnie Garcia <vinnie@coev.co>",
   "license": "MIT",
   "devDependencies": {
-    "argg": "0.0.1",
-    "babel": "^4.5.1",
-    "babel-eslint": "^1.0.13",
-    "coveralls": "^2.11.2",
-    "eslint": "^0.16.0",
-    "istanbul": "^0.3.7",
-    "plato": "^1.4.0",
-    "tape": "^3.5.0"
+    "argg": "0.0.2",
+    "babel": "^5",
+    "babel-eslint": "^4.1.0",
+    "coveralls": "^2.11.4",
+    "eslint": "^1.2.1",
+    "istanbul": "^0.3.18",
+    "plato": "^1.5.0",
+    "tape": "^4.2.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
- Updated modules to latest versions
- Babel upgrade from 4->5 caused changes to commands
- Tests now run in es6 mode with babel-node in development (`npm run tape`, not the coverage tasks)
- Major version bumped to 2.0
